### PR TITLE
AI Fix: Insecure Cipher Configuration

### DIFF
--- a/src/main/java/org/example/Msg.java
+++ b/src/main/java/org/example/Msg.java
@@ -28,7 +28,7 @@ public class Msg {
 //	}
 
     public void encrypt() throws GeneralSecurityException, BadPaddingException {
-        Cipher c = Cipher.getInstance("AES");
+Cipher c = Cipher.getInstance("AES/CBC/PKCS5Padding"); SecretKeySpec keySpec = new SecretKeySpec(key, "AES"); IvParameterSpec ivSpec = new IvParameterSpec(iv); c.init(Cipher.ENCRYPT_MODE, keySpec, ivSpec);
     }
 
     public void encryptAlgFromVar() throws GeneralSecurityException, BadPaddingException {


### PR DESCRIPTION
### AI-Generated Fix

The original code snippet uses the AES algorithm without specifying a mode or padding scheme, which can lead to insecure configurations. By explicitly defining the mode (CBC) and padding (PKCS5Padding), the solution ensures compliance with modern cryptographic standards. Additionally, using an initialization vector (IV) enhances security by preventing identical plaintext blocks from producing identical ciphertexts, thus mitigating risks of pattern attacks.

_This fix was generated by the SecAI plugin._