### PR TITLE
AI Fix: Weak Key Generation

### DIFF
--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -22,9 +22,9 @@ public class Main {
             KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
 RSAKeyGenParameterSpec parameters = new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4);
             generator.initialize(parameters, new SecureRandom());
-            KeyPair keyPair = generator.generateKeyPair();
-        }
-        public void correctBigInteger() throws GeneralSecurityException {
+KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+generator.initialize(2048, SecureRandom.getInstanceStrong());
+KeyPair keyPair = generator.generateKeyPair();
             int keySize = 4096;
             KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
             RSAKeyGenParameterSpec parameters = new RSAKeyGenParameterSpec(keySize, BigInteger.valueOf(65537));


### PR DESCRIPTION
### AI-Generated Fix

The original code may generate keys with insufficient strength or randomness, leading to weak key material. By using SecureRandom.getInstanceStrong(), the solution ensures that the random number generator used is of high quality, providing better entropy. Additionally, initializing the KeyPairGenerator with a key size of 2048 bits aligns with current security standards, enhancing the cryptographic strength of the generated keys. This approach mitigates the risk of vulnerabilities associated with weak key generation.

_This fix was generated by the SecAI plugin._